### PR TITLE
remove profile examples

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,8 +28,6 @@ RSpec.configure do |config|
     config.default_formatter = "doc"
   end
 
-  config.profile_examples = 10
-
   config.order = :random
 
   Kernel.srand config.seed


### PR DESCRIPTION
Delete profile examples in `spec_helper.rb` to get rid of the annoying output when we run the test suite.