### PR TITLE
68 company admin configuratinos

### DIFF
--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -14,7 +14,8 @@ class Company < ActiveRecord::Base
   end
 
   def collaborators
-    User.where(company_id: id)
+    users = User.where(company_id: id)
+    users.reject { |u| u.roles.include?(Role.find_by(name: "company_admin")) }
   end
 
   def former_collaborators

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -15,12 +15,12 @@ class Company < ActiveRecord::Base
 
   def collaborators
     users = User.where(company_id: id)
-    users.reject { |u| u.company_admin? }
+    users.reject(&:company_admin?)
   end
 
   def company_admins
     users = User.where(company_id: id)
-    users.select { |u| u.company_admin? }
+    users.select(&:company_admin?)
   end
 
   def former_collaborators

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -15,12 +15,12 @@ class Company < ActiveRecord::Base
 
   def collaborators
     users = User.where(company_id: id)
-    users.reject { |u| u.roles.include?(Role.find_by(name: "company_admin")) }
+    users.reject { |u| u.company_admin? }
   end
 
   def company_admins
     users = User.where(company_id: id)
-    users.select { |u| u.roles.include?(Role.find_by(name: "company_admin")) }
+    users.select { |u| u.company_admin? }
   end
 
   def former_collaborators

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -18,6 +18,11 @@ class Company < ActiveRecord::Base
     users.reject { |u| u.roles.include?(Role.find_by(name: "company_admin")) }
   end
 
+  def company_admins
+    users = User.where(company_id: id)
+    users.select { |u| u.roles.include?(Role.find_by(name: "company_admin")) }
+  end
+
   def former_collaborators
     User.where(company_id: id)
   end

--- a/app/views/companies/users/index.html.erb
+++ b/app/views/companies/users/index.html.erb
@@ -11,40 +11,65 @@
     <div class="row">
       <%= render 'layouts/sidebar' %>
 
-      <div class="col-md-9 collaborators">
+      <div class="col-md-9">
         <h2 id="content-header">Collaborators</h2>
         <% if current_user.company_admin? %>
-          <h4><%= link_to "Add Collaborator", new_company_user_path(company: current_company.url) %></h4>
+          <h3><%= link_to "Add Collaborator", new_company_user_path(company: current_company.url) %></h3>
         <% end %>
 
-        <div class="table-responsive">
-          <table class="table table-striped orders">
+          <div class="collaborators">
+            <div class="table-responsive">
+              <table class="table table-striped">
+                <tr>
+                  <th>Username</th>
+                  <th>Email</th>
+                  <th></th>
+                </tr>
 
-            <tr>
-              <th>Username</th>
-              <th>Email</th>
-              <th></th>
-            </tr>
-
-            <% if current_company.collaborators %>
-              <% current_company.collaborators.each do |collaborator| %>
-                <tr id="collaborator-<%= collaborator.id %>">
-                <%= content_tag_for :tr, collaborator do %>
-                  <td><%= collaborator.username %></td>
-                  <td><%= collaborator.email %></td>
-                  <% if current_user.company_admin? && collaborator.former_collaborator? %>
-                    <td class="reinstate"><%= link_to "Reinstate", reinstate_company_user_path(company: current_company.url, id: collaborator.id, reinstate: "reinstate"), method: :post %></td>
-                    <% elsif current_user.company_admin? %>
-                      <td class="remove"><%= link_to "Remove", remove_collaborator_company_user_path(company: current_company.url, id: collaborator.id), method: :post %></td>
+                <% if current_company.collaborators %>
+                  <% current_company.collaborators.each do |collaborator| %>
+                    <tr id="collaborator-<%= collaborator.id %>">
+                    <%= content_tag_for :tr, collaborator do %>
+                      <td><%= collaborator.username %></td>
+                      <td><%= collaborator.email %></td>
+                      <% if current_user.company_admin? && collaborator.former_collaborator? %>
+                        <td class="reinstate"><%= link_to "Reinstate", reinstate_company_user_path(company: current_company.url, id: collaborator.id, reinstate: "reinstate"), method: :post %></td>
+                        <% elsif current_user.company_admin? %>
+                          <td class="remove"><%= link_to "Remove", remove_collaborator_company_user_path(company: current_company.url, id: collaborator.id), method: :post %></td>
+                        <% end %>
+                      </tr>
                     <% end %>
-                  </tr>
+                  <% end %>
                 <% end %>
-              <% end %>
-            <% end %>
-          </table>
+              </table>
+            </div>
+          </div>
+
+          <div class="admins">
+            <h2 id="content-header">Company Admins</h2>
+            <div class="table-responsive">
+              <table class="table table-striped">
+                <tr>
+                  <th>Username</th>
+                  <th>Email</th>
+                  <th></th>
+                </tr>
+
+                <% current_company.company_admins.each do |admin| %>
+                  <tr id="collaborator-<%= admin.id %>">
+                  <%= content_tag_for :tr, admin do %>
+                    <td><%= admin.username %></td>
+                    <td><%= admin.email %></td>
+                    <td></td>
+                  </tr>
+                  <% end %>
+                <% end %>
+              </table>
+            </div>
+          </div>
         </div>
       </div>
     </div>
   </div>
-
+</div>
 <hr>

--- a/app/views/companies/users/new.html.erb
+++ b/app/views/companies/users/new.html.erb
@@ -52,7 +52,11 @@
             <%= content_tag_for :tr, collaborator do %>
               <td><%= collaborator.username %></td>
               <td><%= collaborator.email %></td>
-              <td id="remove"><%= link_to "Remove", company_user_path(company: current_company.url, id: collaborator.id), method: :put %>
+              <% if current_user.company_admin? && collaborator.former_collaborator? %>
+              <td class="reinstate"><%= link_to "Reinstate", reinstate_company_user_path(company: current_company.url, id: collaborator.id, reinstate: "reinstate"), method: :post %></td>
+              <% elsif current_user.company_admin? %>
+                <td class="remove"><%= link_to "Remove", remove_collaborator_company_user_path(company: current_company.url, id: collaborator.id), method: :post %></td>
+              <% end %>
             <% end %>
           <% end %>
         <% end %>

--- a/spec/features/collaborator_views_admin_pages_spec.rb
+++ b/spec/features/collaborator_views_admin_pages_spec.rb
@@ -3,13 +3,13 @@ require "rails_helper"
 RSpec.describe "collaborator views admin pages", type: :feature do
   let!(:company) { Fabricate(:company) }
   let!(:admin) { Fabricate(:user,
-                           company_id: company.id,
-                           roles: %w(company_admin)) }
+                            company_id: company.id,
+                            roles: %w(company_admin)) }
   let!(:collaborator) { Fabricate(:user,
-                          username: "collaborator",
-                          company_id: company.id,
-                          roles: %w(collaborator),
-                          email: "collaborator@email.com") }
+                                   username: "collaborator",
+                                   company_id: company.id,
+                                   roles: %w(collaborator),
+                                   email: "collaborator@email.com") }
 
   context "a company collaborator" do
     it "views the admin pages" do

--- a/spec/features/collaborator_views_admin_pages_spec.rb
+++ b/spec/features/collaborator_views_admin_pages_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe "collaborator views admin pages", type: :feature do
+  let!(:company) { Fabricate(:company) }
+  let!(:admin) { Fabricate(:user,
+                           company_id: company.id,
+                           roles: %w(company_admin)) }
+  let!(:collaborator) { Fabricate(:user,
+                          username: "collaborator",
+                          company_id: company.id,
+                          roles: %w(collaborator),
+                          email: "collaborator@email.com") }
+
+  context "a company collaborator" do
+    it "views the admin pages" do
+      login_as(collaborator, root_path)
+
+      click_link "Account"
+      click_link "#{company.name}'s dashboard"
+
+      expect(current_path).to eq company_dashboard_path(company: company.url)
+
+      click_link "Collaborators"
+
+      expect(page).to_not have_link "Add Collaborator"
+
+      within(".collaborators") do
+        expect(page).to have_content collaborator.username
+        expect(page).to have_content collaborator.email
+        expect(page).to_not have_link "Remove"
+      end
+
+      within(".admins") do
+        expect(page).to have_content admin.username
+        expect(page).to have_content admin.email
+      end
+    end
+  end
+end

--- a/spec/features/company_admin_manages_collaborators_spec.rb
+++ b/spec/features/company_admin_manages_collaborators_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "company admin manages collaborators", type: :feature do
 
       click_link "Collaborators"
 
-      within(".table-responsive .user:last-of-type") do
+      within(".collaborators") do
         expect(page).to have_content user.username
         expect(page).to have_content user.email
         expect(page).to_not have_link "Reinstate"
@@ -33,7 +33,7 @@ RSpec.describe "company admin manages collaborators", type: :feature do
       expect(user.collaborator?).to eq (false)
       expect(user.former_collaborator?).to eq (true)
 
-      within(".table-responsive .user:last-of-type") do
+      within(".collaborators") do
         expect(page).to have_content user.username
         expect(page).to have_content user.email
         expect(page).to_not have_link "Remove"
@@ -54,7 +54,7 @@ RSpec.describe "company admin manages collaborators", type: :feature do
 
       click_link "Collaborators"
 
-      within(".table-responsive .user:last-of-type") do
+      within(".collaborators") do
         expect(page).to have_content user.username
         expect(page).to have_content user.email
 
@@ -63,6 +63,23 @@ RSpec.describe "company admin manages collaborators", type: :feature do
 
         expect(page).to_not have_link "Reinstate"
         click_link "Remove"
+      end
+    end
+
+    it "does appear in list of company admins" do
+      login_as(admin, root_path)
+
+      click_link "Account"
+      click_link "#{company.name}'s dashboard"
+
+      expect(current_path).to eq company_dashboard_path(company: company.url)
+
+      click_link "Collaborators"
+
+      within(".admins") do
+        expect(page).to have_content admin.username
+        expect(page).to have_content admin.email
+        expect(page).to_not have_link "Reinstate"
       end
     end
   end

--- a/spec/features/company_admin_manages_collaborators_spec.rb
+++ b/spec/features/company_admin_manages_collaborators_spec.rb
@@ -43,5 +43,27 @@ RSpec.describe "company admin manages collaborators", type: :feature do
       expect(user.collaborator?).to eq(true)
       expect(user.former_collaborator?).to eq(false)
     end
+
+    it "does not appear in list of collaborators" do
+      login_as(admin, root_path)
+
+      click_link "Account"
+      click_link "#{company.name}'s dashboard"
+
+      expect(current_path).to eq company_dashboard_path(company: company.url)
+
+      click_link "Collaborators"
+
+      within(".table-responsive .user:last-of-type") do
+        expect(page).to have_content user.username
+        expect(page).to have_content user.email
+
+        expect(page).to_not have_content admin.username
+        expect(page).to_not have_content admin.email
+
+        expect(page).to_not have_link "Reinstate"
+        click_link "Remove"
+      end
+    end
   end
 end

--- a/spec/features/company_admin_manages_collaborators_spec.rb
+++ b/spec/features/company_admin_manages_collaborators_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "company admin manages collaborators", type: :feature do
   let!(:user) { Fabricate(:user,
                           username: "collaborator",
                           company_id: company.id,
-                          roles: %w(collaborator@gmail.com),
+                          roles: %w(collaborator),
                           email: "collaborator@email.com") }
 
   context "a company admin" do


### PR DESCRIPTION
closes #68 

- admin does not appear in collaborators list 
- admin appears in company admin page, can't remove company admins 
- add remove/reinstate functionality in the companies/users#new show page 

- improve company admin feature tests
- add collaborator feature tests